### PR TITLE
APP-77 Fix error when trying to flash cc32xx gpio app

### DIFF
--- a/gpiocontrol/source/cc32xx/CMakeLists.txt
+++ b/gpiocontrol/source/cc32xx/CMakeLists.txt
@@ -19,10 +19,10 @@ project(C-SDK-sample)
 enable_language(C)
 
 # Target-independent flags.
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -Wall -Wextra")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -Wall -Wextra -g")
 
 # Our application name.
-set(APP_NAME demo_client)
+set(APP_NAME demo_client.afx)
 
 # Demo executable.
 add_executable(${APP_NAME} src/kaa_demo.c)


### PR DESCRIPTION
According to documentation, name of the app must contain .afk extension.
Debug symbols are enabled. This is required by GDB script.

See: http://docs.kaaproject.org/display/KAA/Texas+Instruments+CC3200
