### PR TITLE
APP-81 Fix CMAKE_BUILD_TYPE

### DIFF
--- a/cassandrademo/source/c/build.sh
+++ b/cassandrademo/source/c/build.sh
@@ -56,7 +56,7 @@ function build_thirdparty {
     then
         cd $KAA_LIB_PATH &&
         mkdir -p $BUILD_DIR && cd $BUILD_DIR &&
-        cmake -DKAA_DEBUG_ENABLED=1 \
+        cmake -DCMAKE_BUILD_TYPE=Debug \
               -DKAA_WITHOUT_EVENTS=1 \
               -DKAA_WITHOUT_CONFIGURATION=1 \
               -DKAA_WITHOUT_NOTIFICATION=1 \

--- a/configurationdemo/source/c/build.sh
+++ b/configurationdemo/source/c/build.sh
@@ -111,7 +111,7 @@ function build_app {
           -DKAA_PRODUCE_BINARY=$KAA_PRODUCE_BINARY \
           -DWIFI_SSID=$SSID \
           -DWIFI_PASSWORD=$PASSWORD \
-          -DKAA_DEBUG_ENABLED=1 \
+          -DCMAKE_BUILD_TYPE=Debug \
           -DKAA_WITHOUT_EVENTS=1 \
           -DKAA_WITHOUT_LOGGING=1 \
           -DKAA_MAX_LOG_LEVEL=3 \

--- a/configurationdemo/source/cpp/build.bat
+++ b/configurationdemo/source/cpp/build.bat
@@ -76,7 +76,7 @@ goto help
         md %BUILD_DIR%
         cd %BUILD_DIR%
         cmake -G "NMake Makefiles" ^
-	      -DKAA_DEBUG_ENABLED=1 ^
+	      -DCMAKE_BUILD_TYPE=Debug ^
               -DKAA_WITHOUT_EVENTS=1 ^
               -DKAA_WITHOUT_LOGGING=1 ^
               -DKAA_WITHOUT_NOTIFICATIONS=1 ^

--- a/configurationdemo/source/cpp/build.sh
+++ b/configurationdemo/source/cpp/build.sh
@@ -73,7 +73,7 @@ function build_thirdparty {
         chmod 755 ./avrogen.sh &&
         ./avrogen.sh && 
         mkdir -p $BUILD_DIR && cd $BUILD_DIR &&
-        cmake -DKAA_DEBUG_ENABLED=1 \
+        cmake -DCMAKE_BUILD_TYPE=Debug \
               -DKAA_WITHOUT_EVENTS=1 \
               -DKAA_WITHOUT_LOGGING=1 \
               -DKAA_WITHOUT_NOTIFICATIONS=1 \

--- a/configurationdemo/source/esp8266/build.sh
+++ b/configurationdemo/source/esp8266/build.sh
@@ -61,7 +61,7 @@ function build_thirdparty {
     then
         cd $KAA_LIB_PATH &&
         mkdir -p $BUILD_DIR && cd $BUILD_DIR &&
-        cmake -DKAA_DEBUG_ENABLED=0 \
+        cmake -DCMAKE_BUILD_TYPE=MinSizeRel \
               -DKAA_MAX_LOG_LEVEL=4 \
               -DKAA_PLATFORM=esp8266 \
               -DCMAKE_TOOLCHAIN_FILE=../toolchains/esp8266.cmake \

--- a/gpiocontrol/source/esp8266/build.sh
+++ b/gpiocontrol/source/esp8266/build.sh
@@ -68,7 +68,7 @@ function build_thirdparty {
     then
         cd $KAA_LIB_PATH &&
         mkdir -p $BUILD_DIR && cd $BUILD_DIR &&
-        cmake -DKAA_DEBUG_ENABLED=0 \
+        cmake -DCMAKE_BUILD_TYPE=MinSizeRel \
               -DKAA_MAX_LOG_LEVEL=3 \
               -DKAA_PLATFORM=esp8266 \
               -DCMAKE_TOOLCHAIN_FILE=../toolchains/esp8266.cmake \

--- a/notificationdemo/source/c/build.sh
+++ b/notificationdemo/source/c/build.sh
@@ -73,7 +73,7 @@ function build_thirdparty {
     then
         cd $KAA_LIB_PATH &&
         mkdir -p $BUILD_DIR && cd $BUILD_DIR &&
-        cmake -DKAA_DEBUG_ENABLED=1 \
+        cmake -DCMAKE_BUILD_TYPE=Debug \
               -DKAA_WITHOUT_CONFIGURATION=1 \
               -DKAA_WITHOUT_EVENTS=1 \
               -DKAA_WITHOUT_LOGGING=1 \

--- a/notificationdemo/source/cpp/build.bat
+++ b/notificationdemo/source/cpp/build.bat
@@ -76,7 +76,7 @@ goto help
         md %BUILD_DIR%
         cd %BUILD_DIR%
         cmake -G "NMake Makefiles" ^
-	      -DKAA_DEBUG_ENABLED=1 ^
+	      -DCMAKE_BUILD_TYPE=Debug ^
               -DKAA_WITHOUT_EVENTS=1 ^
               -DKAA_WITHOUT_CONFIGURATION=1 ^
               -DKAA_WITHOUT_LOGGING=1 ^

--- a/notificationdemo/source/cpp/build.sh
+++ b/notificationdemo/source/cpp/build.sh
@@ -73,7 +73,7 @@ function build_thirdparty {
         chmod 755 ./avrogen.sh &&
         ./avrogen.sh && 
         mkdir -p $BUILD_DIR && cd $BUILD_DIR &&
-        cmake -DKAA_DEBUG_ENABLED=1 \
+        cmake -DCMAKE_BUILD_TYPE=Debug \
               -DKAA_WITHOUT_EVENTS=1 \
               -DKAA_WITHOUT_CONFIGURATION=1 \
               -DKAA_WITHOUT_LOGGING=1 \

--- a/powerplant/source/cpp/build.sh
+++ b/powerplant/source/cpp/build.sh
@@ -61,7 +61,7 @@ function build_thirdparty {
         chmod 755 ./avrogen.sh &&
         ./avrogen.sh && 
         mkdir -p $BUILD_DIR && cd $BUILD_DIR &&
-        cmake -DKAA_DEBUG_ENABLED=1 \
+        cmake -DCMAKE_BUILD_TYPE=Debug \
               -DKAA_WITHOUT_EVENTS=1 \
               -DKAA_WITHOUT_NOTIFICATIONS=1 \
               -DKAA_WITHOUT_OPERATION_LONG_POLL_CHANNEL=1 \

--- a/sparkdemo/source/cpp/build.bat
+++ b/sparkdemo/source/cpp/build.bat
@@ -76,7 +76,7 @@ goto help
         md %BUILD_DIR%
         cd %BUILD_DIR%
         cmake -G "NMake Makefiles" ^
-          -DKAA_DEBUG_ENABLED=1 ^
+          -DCMAKE_BUILD_TYPE=Debug ^
               -DKAA_WITHOUT_EVENTS=1 ^
               -DKAA_WITHOUT_CONFIGURATION=1 ^
               -DKAA_WITHOUT_NOTIFICATIONS=1 ^

--- a/sparkdemo/source/cpp/build.sh
+++ b/sparkdemo/source/cpp/build.sh
@@ -73,7 +73,7 @@ function build_thirdparty {
         chmod 755 ./avrogen.sh &&
         ./avrogen.sh && 
         mkdir -p $BUILD_DIR && cd $BUILD_DIR &&
-        cmake -DKAA_DEBUG_ENABLED=1 \
+        cmake -DCMAKE_BUILD_TYPE=Debug \
               -DKAA_WITHOUT_EVENTS=1 \
               -DKAA_WITHOUT_CONFIGURATION=1 \
               -DKAA_WITHOUT_NOTIFICATIONS=1 \

--- a/vehicletelemetry/source/cpp/build.sh
+++ b/vehicletelemetry/source/cpp/build.sh
@@ -58,7 +58,7 @@ function build_thirdparty {
         chmod 755 ./avrogen.sh &&
         ./avrogen.sh && 
         mkdir -p $BUILD_DIR && cd $BUILD_DIR &&
-        cmake -DKAA_DEBUG_ENABLED=1 \
+        cmake -DCMAKE_BUILD_TYPE=Debug \
               -DKAA_WITHOUT_EVENTS=1 \
               -DKAA_WITHOUT_CONFIGURATION=1 \
               -DKAA_WITHOUT_NOTIFICATIONS=1 \


### PR DESCRIPTION
The default CMAKE_BUILD_TYPE is now used instead of custom
KAA_DEBUG_ENABLED.
