### PR TITLE
Revert "Update project version"

### DIFF
--- a/activationdemo/pom.xml
+++ b/activationdemo/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.kaaproject.kaa</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
         <artifactId>examples</artifactId>
     </parent>
     <groupId>org.kaaproject.kaa.examples</groupId>

--- a/cassandrademo/pom.xml
+++ b/cassandrademo/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>examples</artifactId>
         <groupId>org.kaaproject.kaa</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.kaaproject.kaa.examples</groupId>

--- a/cellmonitor/pom.xml
+++ b/cellmonitor/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.kaaproject.kaa</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
         <artifactId>examples</artifactId>
     </parent>
     <groupId>org.kaaproject.kaa.examples</groupId>

--- a/cityguide/pom.xml
+++ b/cityguide/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.kaaproject.kaa</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
         <artifactId>examples</artifactId>
     </parent>
     <groupId>org.kaaproject.kaa.examples</groupId>

--- a/citylights-controller/pom.xml
+++ b/citylights-controller/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.kaaproject.kaa</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
         <artifactId>examples</artifactId>
     </parent>
     <groupId>org.kaaproject.kaa.examples</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.kaaproject.kaa</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
         <artifactId>examples</artifactId>
     </parent>
     <groupId>org.kaaproject.kaa.examples</groupId>

--- a/configurationdemo/pom.xml
+++ b/configurationdemo/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.kaaproject.kaa</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
         <artifactId>examples</artifactId>
     </parent>
     <groupId>org.kaaproject.kaa.examples</groupId>

--- a/connectedcar/pom.xml
+++ b/connectedcar/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.kaaproject.kaa</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
         <artifactId>examples</artifactId>
     </parent>
     <groupId>org.kaaproject.kaa.examples</groupId>

--- a/datacollectiondemo/pom.xml
+++ b/datacollectiondemo/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.kaaproject.kaa</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
         <artifactId>examples</artifactId>
     </parent>
     <groupId>org.kaaproject.kaa.examples</groupId>

--- a/econais/ec19d/pom.xml
+++ b/econais/ec19d/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.kaaproject.kaa.examples</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
         <artifactId>econais</artifactId>
     </parent>
     <groupId>org.kaaproject.kaa.examples.econais</groupId>

--- a/econais/ec19d/streetlight-driver/pom.xml
+++ b/econais/ec19d/streetlight-driver/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.kaaproject.kaa.examples.econais</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
         <artifactId>ec19d</artifactId>
     </parent>
     <groupId>org.kaaproject.kaa.examples.econais.ec19d</groupId>

--- a/econais/ec19d/trafficlights-driver/pom.xml
+++ b/econais/ec19d/trafficlights-driver/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.kaaproject.kaa.examples.econais</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
         <artifactId>ec19d</artifactId>
     </parent>
     <groupId>org.kaaproject.kaa.examples.econais.ec19d</groupId>

--- a/econais/pom.xml
+++ b/econais/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.kaaproject.kaa</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
         <artifactId>examples</artifactId>
     </parent>
     <groupId>org.kaaproject.kaa.examples</groupId>

--- a/eventdemo/pom.xml
+++ b/eventdemo/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.kaaproject.kaa</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
         <artifactId>examples</artifactId>
     </parent>
     <groupId>org.kaaproject.kaa.examples</groupId>

--- a/gpiocontrol/pom.xml
+++ b/gpiocontrol/pom.xml
@@ -20,7 +20,7 @@
   <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.kaaproject.kaa</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
         <artifactId>examples</artifactId>
     </parent>
     <groupId>org.kaaproject.kaa.examples</groupId>

--- a/iotworld/pom.xml
+++ b/iotworld/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.kaaproject.kaa</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
         <artifactId>examples</artifactId>
     </parent>
     <groupId>org.kaaproject.kaa.examples</groupId>

--- a/notificationdemo/pom.xml
+++ b/notificationdemo/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.kaaproject.kaa</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
         <artifactId>examples</artifactId>
     </parent>
     <groupId>org.kaaproject.kaa.examples</groupId>

--- a/ota/pom.xml
+++ b/ota/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.kaaproject.kaa</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
         <artifactId>examples</artifactId>
     </parent>
     <groupId>org.kaaproject.kaa.examples</groupId>

--- a/photoframe/pom.xml
+++ b/photoframe/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.kaaproject.kaa</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
         <artifactId>examples</artifactId>
     </parent>
     <groupId>org.kaaproject.kaa.examples</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.kaaproject.kaa</groupId>
     <artifactId>examples</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Sample applications for Kaa Sandbox</name>
@@ -27,7 +27,7 @@
 
     <properties>
         <main.dir>${basedir}</main.dir>
-        <kaa.version>0.10.0-SNAPSHOT</kaa.version>
+        <kaa.version>0.9.0-SNAPSHOT</kaa.version>
         <jackson.version>2.4.1</jackson.version>
         <avro.version>1.7.5</avro.version>
         <junit.version>4.11</junit.version>

--- a/powerplant-android/pom.xml
+++ b/powerplant-android/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.kaaproject.kaa</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
         <artifactId>examples</artifactId>
     </parent>
     <groupId>org.kaaproject.kaa.examples</groupId>

--- a/powerplant-couchbase-proxy/pom.xml
+++ b/powerplant-couchbase-proxy/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.kaaproject.kaa</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
         <artifactId>examples</artifactId>
     </parent>
     <groupId>org.kaaproject.kaa.examples</groupId>

--- a/powerplant-dashboard/pom.xml
+++ b/powerplant-dashboard/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.kaaproject.kaa</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
         <artifactId>examples</artifactId>
     </parent>
     <groupId>org.kaaproject.kaa.examples</groupId>

--- a/powerplant/pom.xml
+++ b/powerplant/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.kaaproject.kaa</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
         <artifactId>examples</artifactId>
     </parent>
     <groupId>org.kaaproject.kaa.examples</groupId>

--- a/smarthousedemo/pom.xml
+++ b/smarthousedemo/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.kaaproject.kaa</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
         <artifactId>examples</artifactId>
     </parent>
     <groupId>org.kaaproject.kaa.examples</groupId>

--- a/sparkdemo/pom.xml
+++ b/sparkdemo/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>examples</artifactId>
         <groupId>org.kaaproject.kaa</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.kaaproject.kaa.examples</groupId>

--- a/stormdemo/pom.xml
+++ b/stormdemo/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>examples</artifactId>
         <groupId>org.kaaproject.kaa</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.kaaproject.kaa.examples</groupId>

--- a/twitterled/pom.xml
+++ b/twitterled/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.kaaproject.kaa</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
         <artifactId>examples</artifactId>
     </parent>
     <groupId>org.kaaproject.kaa.examples</groupId>

--- a/twitterled/twitterboard/pom.xml
+++ b/twitterled/twitterboard/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.kaaproject.kaa.examples</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
         <artifactId>twitterled</artifactId>
     </parent>
     <groupId>org.kaaproject.kaa.examples.twitterled</groupId>

--- a/twitterled/twittermonitor/pom.xml
+++ b/twitterled/twittermonitor/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.kaaproject.kaa.examples</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
         <artifactId>twitterled</artifactId>
     </parent>
     <groupId>org.kaaproject.kaa.examples.twitterled</groupId>

--- a/vehicletelemetry/pom.xml
+++ b/vehicletelemetry/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.kaaproject.kaa</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
         <artifactId>examples</artifactId>
     </parent>
     <groupId>org.kaaproject.kaa.examples</groupId>

--- a/verifiersdemo/pom.xml
+++ b/verifiersdemo/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.kaaproject.kaa</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
         <artifactId>examples</artifactId>
     </parent>
     <groupId>org.kaaproject.kaa.examples</groupId>

--- a/zeppelindemo/pom.xml
+++ b/zeppelindemo/pom.xml
@@ -21,7 +21,7 @@
 <parent>
     <artifactId>examples</artifactId>
     <groupId>org.kaaproject.kaa</groupId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
 </parent>
 
 <groupId>org.kaaproject.kaa.examples</groupId>


### PR DESCRIPTION
Reverts kaaproject/sample-apps#103

There are next issues with the original pull request:
- not all versions were updated:
  
  ```
  rasen@ashmalko sample-apps(:d020ffd|✔) % git grep -n '1\.3\.0'
  thirdparty/android/floatingactionbutton/AndroidManifest.xml:6:    android:versionName="1.3.0" >
  thirdparty/android/floatingactionbutton/aapt/AndroidManifest.xml:6:    android:versionName="1.3.0" >
  verifiersdemo/source/kits.properties:3:com.twitter.sdk.android:twitter:1.3.0
  zeppelindemo/source/java/pom.xml:23:    <version>1.3.0-SNAPSHOT</version>
  ```
- storm demo depends on core 0.8.1
  
  ```
  rasen@ashmalko sample-apps(:d020ffd|✔) % git grep -n '0\.8\.1'
  stormdemo/source/server/pom.xml:29:        <kaa.version>0.8.1</kaa.version>
  ```
  
  The next release of kaa core is 0.10.0. That also means the last release of sample-apps is broken, as kaa version should be 0.9.0
