### PR TITLE
[Android] Fixed wrong path for sdk in projects.xml file (GpioControl demo)

### DIFF
--- a/gpiocontrol/assembly/src.xml
+++ b/gpiocontrol/assembly/src.xml
@@ -26,54 +26,9 @@
     <includeBaseDirectory>false</includeBaseDirectory>
     <fileSets>
         <fileSet>
-            <directory>${project.basedir}/../thirdparty/android/appcompat_v7_22</directory>
-            <useDefaultExcludes>true</useDefaultExcludes>
-            <outputDirectory>gpiocontrol/appcompat_v7</outputDirectory>
-            <excludes>
-                <exclude>bin/</exclude>
-                <exclude>gen/</exclude>
-            </excludes>
-        </fileSet>
-        <fileSet>
-            <directory>${project.basedir}/../thirdparty/android/recyclerview</directory>
-            <useDefaultExcludes>true</useDefaultExcludes>
-            <outputDirectory>gpiocontrol/recyclerview-v7</outputDirectory>
-            <excludes>
-                <exclude>bin/</exclude>
-                <exclude>gen/</exclude>
-            </excludes>
-        </fileSet>
-        <fileSet>
-            <directory>${project.basedir}/../thirdparty/android/cardview</directory>
-            <useDefaultExcludes>true</useDefaultExcludes>
-            <outputDirectory>gpiocontrol/cardview-v7</outputDirectory>
-            <excludes>
-                <exclude>bin/</exclude>
-                <exclude>gen/</exclude>
-            </excludes>
-        </fileSet>
-        <fileSet>
-            <directory>${project.basedir}/../thirdparty/android/snackbar</directory>
-            <useDefaultExcludes>true</useDefaultExcludes>
-            <outputDirectory>gpiocontrol/snackbar</outputDirectory>
-            <excludes>
-                <exclude>bin/</exclude>
-                <exclude>gen/</exclude>
-            </excludes>
-        </fileSet>
-	    <fileSet>
-            <directory>${project.basedir}/../thirdparty/android/floatingactionbutton</directory>
-            <useDefaultExcludes>true</useDefaultExcludes>
-            <outputDirectory>gpiocontrol/floatingactionbutton</outputDirectory>
-            <excludes>
-                <exclude>bin/</exclude>
-                <exclude>gen/</exclude>
-            </excludes>
-        </fileSet>
-        <fileSet>
             <directory>${project.basedir}/source/android</directory>
             <useDefaultExcludes>true</useDefaultExcludes>
-            <outputDirectory>gpiocontrol/gpiocontrol</outputDirectory>
+            <outputDirectory>gpiocontrol/GpioControl</outputDirectory>
         </fileSet>
     </fileSets>
 </assembly>

--- a/gpiocontrol/resources/projects.xml
+++ b/gpiocontrol/resources/projects.xml
@@ -55,9 +55,9 @@ For more background on the Kaa Event subsystem please refer to the corresponding
         <complexity>REGULAR</complexity>
         <bundleId>gpio_control</bundleId>
         <sourceArchive>android/gpiocontrol.tar.gz</sourceArchive>
-        <projectFolder>gpiocontrol/gpiocontrol</projectFolder>
-        <sdkLibDir>gpiocontrol/gpiocontrol/libs</sdkLibDir>
-        <destBinaryFile>gpiocontrol/gpiocontrol/bin/gpiocontrol-debug.apk</destBinaryFile>
+        <projectFolder>gpiocontrol/GpioControl</projectFolder>
+        <sdkLibDir>gpiocontrol/GpioControl/app/libs</sdkLibDir>
+        <destBinaryFile>gpiocontrol/GpioControl/app/build/outputs/apk/app-debug.apk</destBinaryFile>
     </project>
 
     <project id="gpio_slave_cc">


### PR DESCRIPTION
Fixed wrong path for sdk in projects.xml file, removed redundant dependencies from assembly/src.xml file, fixed outputDirectory in this file to match other android demo's style
