### PR TITLE
APP-357: Long names of Bundles and Demo Apps are cropped

### DIFF
--- a/verifiersdemo/resources/projects.xml
+++ b/verifiersdemo/resources/projects.xml
@@ -435,8 +435,8 @@ Try the following:
     <!--</project>-->
 
     <bundle id="verifiers_demos">
-        <name>User verifiers demos (Endpoint ownership)</name>
-        <description>Kaa user verifiers subsystem demo applications bundle</description>
+        <name>Endpoint ownership</name>
+        <description>Kaa user verifiers and endpoint ownership subsystems demo applications bundle</description>
         <details>
             <![CDATA[
 <p>


### PR DESCRIPTION
Fix verifiers demo name and description;

Review: @Slash32 and @Rib47
