### PR TITLE
projects.xml validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -302,6 +302,27 @@
                     </excludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>xml-maven-plugin</artifactId>
+                <version>1.0.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>validate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <validationSets>
+                        <validationSet>
+                            <dir>.</dir>
+                            <includes>*/resources/projects.xml</includes>
+                            <systemId>common/src/main/resources/demo/projects/demo_projects_schema.xsd</systemId>
+                        </validationSet>
+                    </validationSets>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -317,7 +317,9 @@
                     <validationSets>
                         <validationSet>
                             <dir>.</dir>
-                            <includes>*/resources/projects.xml</includes>
+                            <includes>
+                                <include>*/resources/projects.xml</include>
+                            </includes>
                             <systemId>common/src/main/resources/demo/projects/demo_projects_schema.xsd</systemId>
                         </validationSet>
                     </validationSets>


### PR DESCRIPTION
Added _projects.xml_ schema validation. Validation occurs during build time.
_projects.xml_ file should be located in the _resources_  directory in each app sub-module.
