### PR TITLE
APP-405: Update Objective-C launching description in all sample apps

### DIFF
--- a/configurationdemo/resources/projects.xml
+++ b/configurationdemo/resources/projects.xml
@@ -405,10 +405,11 @@ To launch this sample application on the Kaa Objective-C SDK:
 		Unpack the downloaded archive and run the following command from the directory containing the unpacked source files.
 		
 		<pre>
-			sh build.sh compile
+			sh build.sh
 		</pre>
 		
 		The build script will extract the Kaa SDK, install dependencies with CocoaPods and build the SDK.
+        <blockquote>NOTE: The build script will also install CocoaPods master repository, which may take a few minutes.</blockquote>
 	</li>
 	<li>
 		Open the ConfigurationDemo.xcodeproj file and click the <b>Play</b> button.

--- a/credentialsdemo/resources/projects.xml
+++ b/credentialsdemo/resources/projects.xml
@@ -527,10 +527,11 @@ To launch this sample application on the Kaa Objective-C SDK:
 		Unpack the downloaded archive and run the following command from the directory containing the unpacked source files.
 		
 		<pre>
-			sh build.sh compile
+			sh build.sh
 		</pre>
 		
 		The build script will extract the Kaa SDK, install dependencies with CocoaPods and build the SDK.
+        <blockquote>NOTE: The build script will also install CocoaPods master repository, which may take a few minutes.</blockquote>
 	</li>
 	<li>
 		Open the CredentialsDemo.xcodeproj file and click the <b>Play</b> button.

--- a/datacollectiondemo/resources/projects.xml
+++ b/datacollectiondemo/resources/projects.xml
@@ -437,10 +437,11 @@ To launch this sample application on the Kaa Objective-C SDK:
 		Unpack the downloaded archive and run the following command from the directory containing the unpacked source files.
 		
 		<pre>
-			sh build.sh compile
+			sh build.sh
 		</pre>
 		
 		The build script will extract the Kaa SDK, install dependencies with CocoaPods and build the SDK.
+        <blockquote>NOTE: The build script will also install CocoaPods master repository, which may take a few minutes.</blockquote>
 	</li>
 	<li>
 		Open the DataCollectionDemo.xcodeproj file and click the <b>Play</b> button.

--- a/eventdemo/resources/projects.xml
+++ b/eventdemo/resources/projects.xml
@@ -421,10 +421,11 @@ To launch this sample application on the Kaa Objective-C SDK:
 		Unpack the downloaded archive and run the following command from the directory containing the unpacked source files.
 		
 		<pre>
-			sh build.sh compile
+			sh build.sh
 		</pre>
 		
 		The build script will extract the Kaa SDK, install dependencies with CocoaPods and build the SDK.
+        <blockquote>NOTE: The build script will also install CocoaPods master repository, which may take a few minutes.</blockquote>
 	</li>
 	<li>
 		Open the EventDemo.xcodeproj and click the <b>Play</b> button.

--- a/notificationdemo/resources/projects.xml
+++ b/notificationdemo/resources/projects.xml
@@ -520,10 +520,11 @@ To launch this sample application on the Kaa Objective-C SDK:
 		Unpack the downloaded archive and run the following command from the directory containing the unpacked source files.
 		
 		<pre>
-			sh build.sh compile
+			sh build.sh
 		</pre>
 		
 		The build script will extract the Kaa SDK, install dependencies with CocoaPods and build the SDK.
+        <blockquote>NOTE: The build script will also install CocoaPods master repository, which may take a few minutes.</blockquote>
 	</li>
 	<li>
 		Open the NotificationDemo.xcodeproj file and click the <b>Play</b> button.

--- a/profilingdemo/resources/projects.xml
+++ b/profilingdemo/resources/projects.xml
@@ -278,10 +278,11 @@ To launch this sample application on the Kaa Objective-C SDK:
 		Unpack the downloaded archive and run the following command from the directory containing the unpacked source files.
 		
 		<pre>
-			sh build.sh compile
+			sh build.sh
 		</pre>
 		
 		The build script will extract the Kaa SDK, install dependencies with CocoaPods and build the SDK.
+        <blockquote>NOTE: The build script will also install CocoaPods master repository, which may take a few minutes.</blockquote>
 	</li>
 	<li>
 		Open the ProfilingDemo.xcodeproj file and click the <b>Play</b> button.

--- a/verifiersdemo/resources/projects.xml
+++ b/verifiersdemo/resources/projects.xml
@@ -224,10 +224,11 @@ To launch this sample application on the Kaa Objective-C SDK:
 		Unpack the downloaded archive and run the following command from the directory containing the unpacked source files.
 
 		<pre>
-			sh build.sh compile
+			sh build.sh
 		</pre>
 
 		The build script will extract the Kaa SDK, install dependencies with CocoaPods and build the SDK.
+        <blockquote>NOTE: The build script will also install CocoaPods master repository, which may take a few minutes.</blockquote>
 	</li>
 	<li>
 		Open the EndpointOwnershipDemo.xcodeproj file and click the <b>Play</b> button.


### PR DESCRIPTION
Replace "sh build.sh compile" from Objective-C launching instructions with "sh build.sh";
Add build notes;

Review: @am1kk and @Slash32 
