### PR TITLE
APP-462: [C++ SDK] Error build a sample app from build.bat in the windows

### DIFF
--- a/common/build-scripts/build.bat
+++ b/common/build-scripts/build.bat
@@ -50,7 +50,7 @@ if /i %1 == clean goto clean
 
 goto help
 
-:build_app
+:build
     IF NOT EXIST %KAA_C_LIB_HEADER_PATH%\NUL (
        IF NOT EXIST %KAA_CPP_LIB_HEADER_PATH%\NUL (
         for /R %PROJECT_HOME% %%f in (kaa-c*.tar.gz) do (


### PR DESCRIPTION
Note! It looks like need to change "build" to a define. What do you think?