### PR TITLE
Fixed Android App. calling start method just after creation of kaaMaanager

### DIFF
--- a/cellmonitor/source/android/app/src/main/java/org/kaaproject/kaa/demo/cellmonitor/MainActivity.java
+++ b/cellmonitor/source/android/app/src/main/java/org/kaaproject/kaa/demo/cellmonitor/MainActivity.java
@@ -85,6 +85,7 @@ public class MainActivity extends AppCompatActivity {
         }
 
         kaaManager = new KaaManager(cellCallback);
+        kaaManager.start(this);
 
         updateContent();
         initActionBar();


### PR DESCRIPTION

The kaaManager was created in onCreate() method  and kaaManager was stopped  in onDestroy method,  but it was never started by invoking start method.  Adding this line fixed the app and now it's working.