### PR TITLE
Revert "APP-486: dropped obsolete menu_device_list.xml file"

### DIFF
--- a/gpiocontrol/source/android/app/src/main/res/menu/menu_device_list.xml
+++ b/gpiocontrol/source/android/app/src/main/res/menu/menu_device_list.xml
@@ -1,0 +1,27 @@
+<!--
+
+     Copyright 2014-2016 CyberVision, Inc.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/action_update"
+        android:icon="@drawable/ic_refresh_black_24dp"
+        android:title="Update"
+        app:showAsAction="always"/>
+</menu>


### PR DESCRIPTION
The file was found to be actually used and is required for build

This reverts commit 396667d5a3497b258b8aa95b0f25ec65ed89d63b (Merged in #594).