### PR TITLE
APP-609: Fixed compilation of C++ Event demo

### DIFF
--- a/event/source/cpp/config.cmake
+++ b/event/source/cpp/config.cmake
@@ -21,5 +21,7 @@ set(KAA_WITHOUT_CONFIGURATION 1)
 set(KAA_WITHOUT_NOTIFICATIONS 1)
 set(KAA_WITHOUT_LOGGING 1)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive")
+
 add_executable(demo_client src/KaaDemo.cpp)
 target_link_libraries(demo_client kaacpp)


### PR DESCRIPTION
Reproducible on new GCC (5.4.0 and later)